### PR TITLE
Fixes a bug with wavelength range propagation and other minor issues

### DIFF
--- a/src/pymusepipe/align_pipe.py
+++ b/src/pymusepipe/align_pipe.py
@@ -1966,7 +1966,23 @@ class AlignMuseDataset(object):
             if newfits_name is None:
                 newfits_name = self.list_name_museimages[nima].replace(
                     ".fits", "_shift.fits")
-            self.list_offmuse_hdu[nima].writeto(newfits_name, overwrite=True)
+            #
+            newhdr = copy.copy(self.list_muse_hdu[nima].header)
+
+            # Using input offset or total
+            total_off_pixel, total_off_arcsec = self._sort_offset_pixel_arcsec(self.list_muse_hdu[nima], self._total_off_pixel[nima],
+                                                                               None)
+            # Shifting the CRPIX values in the header
+            newhdr['CRPIX1'] += total_off_pixel[0]
+            newhdr['CRPIX2'] += total_off_pixel[1]
+
+            hdu_offmuse = pyfits.PrimaryHDU(self.list_muse_hdu[nima].data, header=newhdr)
+
+            img_to_save, _, _ = self._align_hdu(hdu_target=hdu_offmuse, hdu_to_align=self.reference_hdu,
+                                   target_rotation=self._total_rotangles[nima], to_align_rotation=0,
+                                   conversion_factor=1.)
+            img_to_save.writeto(newfits_name, overwrite=True)
+            # self.list_offmuse_hdu[nima].writeto(newfits_name, overwrite=True)
         else:
             upipe.print_error("There are not yet any new hdu to save")
 

--- a/src/pymusepipe/align_pipe.py
+++ b/src/pymusepipe/align_pipe.py
@@ -39,6 +39,7 @@ from astropy import units as u
 
 # Import mpdaf
 from mpdaf.obj import Image, WCS
+from seaborn.utils import percentiles
 
 # Import needed modules from pymusepipe
 from . import util_pipe as upipe  # noqua: E402
@@ -1966,10 +1967,10 @@ class AlignMuseDataset(object):
             if newfits_name is None:
                 newfits_name = self.list_name_museimages[nima].replace(
                     ".fits", "_shift.fits")
-            #
+            # Copy header to keep astrometry from original fits
             newhdr = copy.copy(self.list_muse_hdu[nima].header)
 
-            # Using input offset or total
+            # Get total offset in pixels
             total_off_pixel, total_off_arcsec = self._sort_offset_pixel_arcsec(self.list_muse_hdu[nima], self._total_off_pixel[nima],
                                                                                None)
             # Shifting the CRPIX values in the header
@@ -1978,11 +1979,11 @@ class AlignMuseDataset(object):
 
             hdu_offmuse = pyfits.PrimaryHDU(self.list_muse_hdu[nima].data, header=newhdr)
 
+            # Get rotated image
             img_to_save, _, _ = self._align_hdu(hdu_target=hdu_offmuse, hdu_to_align=self.reference_hdu,
                                    target_rotation=self._total_rotangles[nima], to_align_rotation=0,
                                    conversion_factor=1.)
             img_to_save.writeto(newfits_name, overwrite=True)
-            # self.list_offmuse_hdu[nima].writeto(newfits_name, overwrite=True)
         else:
             upipe.print_error("There are not yet any new hdu to save")
 
@@ -2246,11 +2247,13 @@ class AlignMuseDataset(object):
             The 2 arrays (input, reference) after processing
         """
         threshold = kwargs.pop("threshold", self.ima_threshold[nima])
+        percentiles = kwargs.pop("percentiles", (0,100))
+        sigclip = kwargs.pop("sigclip", 0)
 
         return get_normfactor(self.list_offmuse_hdu[nima].data, self.list_proj_refhdu[nima].data,
                               convolve_data1=convolve_muse, convolve_data2=convolve_reference,
                               median_filter=median_filter, border=border,
-                              chunk_size=chunk_size, threshold=threshold)
+                              chunk_size=chunk_size, threshold=threshold, percentiles=percentiles, sigclip=sigclip)
 
     def save_polypar_ima(self, nima=0, beta=None):
         """Saving the input values into the fixed arrays for the polynomial
@@ -2299,11 +2302,13 @@ class AlignMuseDataset(object):
             refhdu = self.list_proj_refhdu[nima]
 
         threshold_muse = kwargs.pop("threshold_muse", self.ima_threshold[nima])
+        percentiles = kwargs.pop("percentiles", (0, 100))
+        sigclip = kwargs.pop("sigclip", 0)
 
         musedata, refdata, polypar = get_normfactor(musehdu.data, refhdu.data,
                                                     convolve_data1=convolve_muse,
                                                     convolve_data2=convolve_reference,
-                                                    threshold=threshold_muse)
+                                                    threshold=threshold_muse, percentiles=percentiles, sigclip=sigclip)
         self.compare(aligned=musedata, reference=refdata, header=musehdu.header,
                      suffix_fig=f"{nima:03d}", **kwargs)
 
@@ -2357,6 +2362,8 @@ class AlignMuseDataset(object):
         chunk_size = kwargs.pop("chunk_size", self.chunk_size)
         savefig = kwargs.pop("savefig", True)
         threshold = kwargs.pop("threshold", 0.)
+        sigclip = kwargs.pop("sigclip", 0.)
+        percentiles = kwargs.pop("percentiles", 0.)
 
         # Getting the data
         _, _, polypar = get_normfactor(aligned, reference,
@@ -2364,7 +2371,9 @@ class AlignMuseDataset(object):
                                        convolve_data2=convolve_reference,
                                        median_filter=median_filter, border=border,
                                        chunk_size=chunk_size,
-                                       threshold=threshold)
+                                       threshold=threshold,
+                                       percentiles=percentiles,
+                                       sigclip=sigclip)
 
         # If normalising, use the polypar slope and background
         if normalise:

--- a/src/pymusepipe/align_pipe.py
+++ b/src/pymusepipe/align_pipe.py
@@ -39,7 +39,6 @@ from astropy import units as u
 
 # Import mpdaf
 from mpdaf.obj import Image, WCS
-from seaborn.utils import percentiles
 
 # Import needed modules from pymusepipe
 from . import util_pipe as upipe  # noqua: E402
@@ -2308,7 +2307,8 @@ class AlignMuseDataset(object):
         musedata, refdata, polypar = get_normfactor(musehdu.data, refhdu.data,
                                                     convolve_data1=convolve_muse,
                                                     convolve_data2=convolve_reference,
-                                                    threshold=threshold_muse, percentiles=percentiles, sigclip=sigclip)
+                                                    threshold=threshold_muse, percentiles=percentiles,
+                                                    sigclip=sigclip)
         self.compare(aligned=musedata, reference=refdata, header=musehdu.header,
                      suffix_fig=f"{nima:03d}", **kwargs)
 
@@ -2363,7 +2363,7 @@ class AlignMuseDataset(object):
         savefig = kwargs.pop("savefig", True)
         threshold = kwargs.pop("threshold", 0.)
         sigclip = kwargs.pop("sigclip", 0.)
-        percentiles = kwargs.pop("percentiles", 0.)
+        percentiles = kwargs.pop("percentiles", (0.,100.))
 
         # Getting the data
         _, _, polypar = get_normfactor(aligned, reference,

--- a/src/pymusepipe/combine.py
+++ b/src/pymusepipe/combine.py
@@ -802,7 +802,7 @@ class MusePointings(SofPipe, PipeRecipes):
             # Spectral coverage for a full mosaic
             upipe.print_info("@@@@@@@ Start creating the full-lambda WCS @@@@@@@")
             self._combined_wcs_name = self.create_combined_wcs(prefix_wcs=prefix_mosaic,
-                                                               lambdaminmax_wcs=lambdaminmax, #_for_mosaic,
+                                                               lambdaminmax_wcs=lambdaminmax,
                                                                refcube_name=wcs_refcube_name,
                                                                folder_refcube="")
 

--- a/src/pymusepipe/combine.py
+++ b/src/pymusepipe/combine.py
@@ -802,7 +802,7 @@ class MusePointings(SofPipe, PipeRecipes):
             # Spectral coverage for a full mosaic
             upipe.print_info("@@@@@@@ Start creating the full-lambda WCS @@@@@@@")
             self._combined_wcs_name = self.create_combined_wcs(prefix_wcs=prefix_mosaic,
-                                                               lambdaminmax_wcs=lambdaminmax_for_mosaic,
+                                                               lambdaminmax_wcs=lambdaminmax, #_for_mosaic,
                                                                refcube_name=wcs_refcube_name,
                                                                folder_refcube="")
 

--- a/src/pymusepipe/target_sample.py
+++ b/src/pymusepipe/target_sample.py
@@ -668,7 +668,7 @@ class MusePipeSample(object):
                                       list_datasets=list_datasets,
                                       folder_refcube=folder_refcube,
                                       pointing_table=pointing_table,
-                                      fakemode=False)
+                                      fakemode=False, **kwargs)
 
         if create_expocubes:
             # Running the individual cubes now with the same WCS reference
@@ -1232,7 +1232,9 @@ class MusePipeSample(object):
         """
         default_comb_folder = self.targets[targetname].combcubes_path
         folder_refcube = kwargs.pop("folder_refcube", default_comb_folder)
+        lambdaminmax = kwargs.pop("lambdaminmax", None)
         self.init_combine(targetname=targetname, **kwargs)
+        kwargs.update({'lambdaminmax': lambdaminmax})
         self.pipes_combine[targetname].create_reference_wcs(pointings_wcs=pointings_wcs,
                                                             mosaic_wcs=mosaic_wcs,
                                                             wcs_refcube_name=wcs_refcube_name,

--- a/src/pymusepipe/target_sample.py
+++ b/src/pymusepipe/target_sample.py
@@ -578,7 +578,7 @@ class MusePipeSample(object):
                            create_expocubes=True, create_pixtables=True,
                            create_pointingcubes=True,
                            name_offset_table=None, folder_offset_table=None,
-                           list_datasets=None, **kwargs):
+                           list_datasets=None, lambdaminmax=None, **kwargs):
         """Finalise the reduction steps by using the offset table, rotating the
         pixeltables, then reconstructing the PIXTABLE_REDUCED, produce reference
         WCS for each pointing, and then run the reconstruction of the final
@@ -594,6 +594,8 @@ class MusePipeSample(object):
         create_pointingcubes: bool
         name_offset_table: str
         folder_offset_table: str
+        list_datasets: list
+        lambdaminmax: list
         **kwargs: include
             wcs_refcube_name: str
                 Reference WCS (cube) to be used to project all cubes
@@ -668,7 +670,7 @@ class MusePipeSample(object):
                                       list_datasets=list_datasets,
                                       folder_refcube=folder_refcube,
                                       pointing_table=pointing_table,
-                                      fakemode=False, **kwargs)
+                                      fakemode=False, lambdaminmax=lambdaminmax)
 
         if create_expocubes:
             # Running the individual cubes now with the same WCS reference
@@ -1226,15 +1228,16 @@ class MusePipeSample(object):
             self.pipes_combine[targetname].run_combine(**kwargs)
 
     def create_reference_wcs(self, targetname=None, pointings_wcs=True, mosaic_wcs=True,
-                             wcs_refcube_name=None, refcube_name=None, **kwargs):
+                             wcs_refcube_name=None, refcube_name=None, lambdaminmax=None,
+                             **kwargs):
         """Run the combine for individual exposures first building up
         a mask.
         """
         default_comb_folder = self.targets[targetname].combcubes_path
         folder_refcube = kwargs.pop("folder_refcube", default_comb_folder)
-        lambdaminmax = kwargs.pop("lambdaminmax", None)
         self.init_combine(targetname=targetname, **kwargs)
-        kwargs.update({'lambdaminmax': lambdaminmax})
+        if lambdaminmax is not None:
+            kwargs.update({'lambdaminmax': lambdaminmax})
         self.pipes_combine[targetname].create_reference_wcs(pointings_wcs=pointings_wcs,
                                                             mosaic_wcs=mosaic_wcs,
                                                             wcs_refcube_name=wcs_refcube_name,

--- a/src/pymusepipe/util_image.py
+++ b/src/pymusepipe/util_image.py
@@ -271,11 +271,13 @@ def regress_odr(x, y, sx, sy, beta0=(0., 1.),
     result = ODR(mydata, linear, beta0=beta0)
 
     if sigclip > 0:
-        diff = ysel - my_linear_model([result.beta[0], result.beta[1]], xsel)
+        r = result.run()
+        r.beta[0] -= minx
+        diff = ysel - my_linear_model([r.beta[0], r.beta[1]], xsel)
         filtered = sigma_clip(diff, sigma=sigclip)
         xnsel, ynsel = xsel[~filtered.mask], ysel[~filtered.mask]
         sxnsel, synsel = sxsel[~filtered.mask], sysel[~filtered.mask]
-        clipdata = RealData(xnsel, ynsel, sx=sxnsel, sy=synsel)
+        clipdata = RealData(xnsel - minx, ynsel, sx=sxnsel, sy=synsel)
         result = ODR(clipdata, linear, beta0=beta0)
 
     # Running the ODR
@@ -396,7 +398,7 @@ def get_normfactor(array1, array2, median_filter=True, border=0,
     d1 = prepare_image(array1+add_background1, median_filter=median_filter, sigma=convolve_data1,
                        border=border)
     d2 = prepare_image(array2, median_filter=median_filter, sigma=convolve_data2, border=border)
-    polypar = get_polynorm(d1, d2, chunk_size=chunk_size, threshold1=threshold)
+    polypar = get_polynorm(d1, d2, chunk_size=chunk_size, threshold1=threshold, sigclip=1.5, percentiles=[30,99.7])
 
     # Returning the processed data
     return d1, d2, polypar

--- a/src/pymusepipe/util_image.py
+++ b/src/pymusepipe/util_image.py
@@ -276,10 +276,12 @@ def regress_odr(x, y, sx, sy, beta0=(0., 1.),
         # Offset from the min of x
         r.beta[0] -= minx
         if sigclip > 0:
+            # clean data with sigma clipping
             diff = y - my_linear_model([r.beta[0], r.beta[1]], x)
             filtered = sigma_clip(diff, sigma=sigclip)
             x, y = x[~filtered.mask], y[~filtered.mask]
             sx, sy = sx[~filtered.mask], sy[~filtered.mask]
+            # Run ODR again on the cleaned data
             r = local_run_odr(x, y, sx, sy, 0)
         return r
     return local_run_odr(xsel, ysel, sxsel, sysel, sigclip)

--- a/src/pymusepipe/util_image.py
+++ b/src/pymusepipe/util_image.py
@@ -365,7 +365,7 @@ def get_flux_range(data, border=15, low=2, high=98):
 
 def get_normfactor(array1, array2, median_filter=True, border=0,
                    convolve_data1=0., convolve_data2=0., chunk_size=10,
-                   threshold=0., add_background1=0):
+                   threshold=0., add_background1=0, percentiles=(0, 100.), sigclip=0):
     """Get the normalisation factor for shifted and projected images. This function
     only consider the input images given by their data (numpy) arrays.
 
@@ -386,6 +386,10 @@ def get_normfactor(array1, array2, median_filter=True, border=0,
         Number of pixels to crop
     threshold: float [None]
         Threshold for the input image flux to consider
+    percentiles : list or tuple of 2 floats
+        Percentiles for the values to consider for linear regression [(0., 100.)
+    sigclip : float
+        Sigma clipping factor for linear regression [0]
 
     Returns
     -------
@@ -398,7 +402,8 @@ def get_normfactor(array1, array2, median_filter=True, border=0,
     d1 = prepare_image(array1+add_background1, median_filter=median_filter, sigma=convolve_data1,
                        border=border)
     d2 = prepare_image(array2, median_filter=median_filter, sigma=convolve_data2, border=border)
-    polypar = get_polynorm(d1, d2, chunk_size=chunk_size, threshold1=threshold, sigclip=1.5, percentiles=[30,99.7])
+    polypar = get_polynorm(d1, d2, chunk_size=chunk_size, threshold1=threshold, sigclip=sigclip,
+                           percentiles=percentiles)
 
     # Returning the processed data
     return d1, d2, polypar


### PR DESCRIPTION
This PR fixes several issues:

- `lambdaminmax` keyword propagation through the `finalise_reduction` step now works properly. Previously, the hard-coded `lambdaminmax_mosaic` was used for wcs creation and subsequent mosaicking, independently on the provided `lambdaminmax`.
- The alligned fits images can be saved now with the correct wcs using `AlignMuseDataset.save_image()`
- Minor fixes in ODR run for sigma-clipping during normalization